### PR TITLE
Always use https://github.com as URL prefix despite what the user's remo...

### DIFF
--- a/lib/anchorman/repo.rb
+++ b/lib/anchorman/repo.rb
@@ -21,7 +21,8 @@ module Anchorman
     private
 
     def github_url_for(*components)
-      [remote.url[0..-5], *components].join('/')
+      repo_string = remote.url.match(/github\.com[\/:](.*)\.git$/)[1]
+      ["https://github.com", repo_string, *components].join('/')
     end
   end
 end

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 describe Anchorman::Repo do
 
   describe "when origin is github" do
+    let(:remote_info) {
+      double("git remote",
+        url: "https://github.com/foobar/myrepo.git",
+        name: "origin")
+    }
     subject(:github_repo) do
-      remote = double("git remote",
-                      url: "https://github.com/foobar/myrepo.git",
-                      name: "origin")
+      remote = remote_info
       repo = double("repo", remote: remote)
 
       Anchorman::Repo.new(repo)
@@ -18,6 +21,17 @@ describe Anchorman::Repo do
 
     it "provides a commit URL" do
       github_repo.commit_url('abc123').should == "[abc123](https://github.com/foobar/myrepo/commit/abc123)"
+    end
+
+    context "when the remote is using SSH instead of a URL" do
+      let(:remote_info) { double("git remote",
+        url: "git@github.com:foobar/myrepo.git",
+        name: "origin")
+      }
+
+      it "still returns a URL" do
+        github_repo.commit_url('abc123').should == "[abc123](https://github.com/foobar/myrepo/commit/abc123)"
+      end
     end
   end
 


### PR DESCRIPTION
Always use https://github.com as URL prefix despite what the user's remote is using (SSH|URL)

Resolves Issue #2
